### PR TITLE
Updated for florincore-lib

### DIFF
--- a/test/unit.js
+++ b/test/unit.js
@@ -11,7 +11,7 @@ describe('Unit', function() {
 
   it('can be created from a number and unit', function() {
     expect(function() {
-      return new Unit(1.2, 'BTC');
+      return new Unit(1.2, 'FLO');
     }).to.not.throw();
   });
 
@@ -23,7 +23,7 @@ describe('Unit', function() {
 
   it('no "new" is required for creating an instance', function() {
     expect(function() {
-      return Unit(1.2, 'BTC');
+      return Unit(1.2, 'FLO');
     }).to.not.throw();
 
     expect(function() {
@@ -31,117 +31,72 @@ describe('Unit', function() {
     }).to.not.throw();
   });
 
-  it('has property accesors "BTC", "mBTC", "uBTC", "bits", and "satoshis"', function() {
-    var unit = new Unit(1.2, 'BTC');
-    unit.BTC.should.equal(1.2);
-    unit.mBTC.should.equal(1200);
-    unit.uBTC.should.equal(1200000);
-    unit.bits.should.equal(1200000);
-    unit.satoshis.should.equal(120000000);
+  it('has property accesors "FLO", "mFLO", and  "uFLO"', function() {
+    var unit = new Unit(1.2, 'FLO');
+    unit.FLO.should.equal(1.2);
+    unit.mFLO.should.equal(1200);
+    unit.uFLO.should.equal(1200000);
   });
 
   it('a string amount is allowed', function() {
     var unit;
 
-    unit = Unit.fromBTC('1.00001');
-    unit.BTC.should.equal(1.00001);
+    unit = Unit.fromFLO('1.00001');
+    unit.FLO.should.equal(1.00001);
 
     unit = Unit.fromMilis('1.00001');
-    unit.mBTC.should.equal(1.00001);
+    unit.mFLO.should.equal(1.00001);
 
     unit = Unit.fromMillis('1.00001');
-    unit.mBTC.should.equal(1.00001);
-
-    unit = Unit.fromBits('100');
-    unit.bits.should.equal(100);
-
-    unit = Unit.fromSatoshis('8999');
-    unit.satoshis.should.equal(8999);
-
+    unit.mFLO.should.equal(1.00001);
+    
     unit = Unit.fromFiat('43', 350);
-    unit.BTC.should.equal(0.12285714);
+    unit.FLO.should.equal(0.12285714);
   });
 
   it('should have constructor helpers', function() {
     var unit;
 
-    unit = Unit.fromBTC(1.00001);
-    unit.BTC.should.equal(1.00001);
+    unit = Unit.fromFLO(1.00001);
+    unit.FLO.should.equal(1.00001);
 
     unit = Unit.fromMilis(1.00001);
-    unit.mBTC.should.equal(1.00001);
-
-    unit = Unit.fromBits(100);
-    unit.bits.should.equal(100);
-
-    unit = Unit.fromSatoshis(8999);
-    unit.satoshis.should.equal(8999);
-
+    unit.mFLO.should.equal(1.00001);
+    
     unit = Unit.fromFiat(43, 350);
-    unit.BTC.should.equal(0.12285714);
+    unit.FLO.should.equal(0.12285714);
   });
 
-  it('converts to satoshis correctly', function() {
-    /* jshint maxstatements: 25 */
-    var unit;
-
-    unit = Unit.fromBTC(1.3);
-    unit.mBTC.should.equal(1300);
-    unit.bits.should.equal(1300000);
-    unit.satoshis.should.equal(130000000);
-
-    unit = Unit.fromMilis(1.3);
-    unit.BTC.should.equal(0.0013);
-    unit.bits.should.equal(1300);
-    unit.satoshis.should.equal(130000);
-
-    unit = Unit.fromBits(1.3);
-    unit.BTC.should.equal(0.0000013);
-    unit.mBTC.should.equal(0.0013);
-    unit.satoshis.should.equal(130);
-
-    unit = Unit.fromSatoshis(3);
-    unit.BTC.should.equal(0.00000003);
-    unit.mBTC.should.equal(0.00003);
-    unit.bits.should.equal(0.03);
-  });
 
   it('takes into account floating point problems', function() {
-    var unit = Unit.fromBTC(0.00000003);
-    unit.mBTC.should.equal(0.00003);
-    unit.bits.should.equal(0.03);
-    unit.satoshis.should.equal(3);
+    var unit = Unit.fromFLO(0.00000003);
+    unit.mFLO.should.equal(0.00003);
+   
   });
 
   it('exposes unit codes', function() {
-    should.exist(Unit.BTC);
-    Unit.BTC.should.equal('BTC');
+    should.exist(Unit.FLO);
+    Unit.FLO.should.equal('FLO');
 
-    should.exist(Unit.mBTC);
-    Unit.mBTC.should.equal('mBTC');
+    should.exist(Unit.mFLO);
+    Unit.mFLO.should.equal('mFLO');
 
-    should.exist(Unit.bits);
-    Unit.bits.should.equal('bits');
-
-    should.exist(Unit.satoshis);
-    Unit.satoshis.should.equal('satoshis');
+    should.exist(Unit.uFLO);
+    Unit.uFLO.should.equal('uFLO');
+    
   });
 
   it('exposes a method that converts to different units', function() {
-    var unit = new Unit(1.3, 'BTC');
-    unit.to(Unit.BTC).should.equal(unit.BTC);
-    unit.to(Unit.mBTC).should.equal(unit.mBTC);
-    unit.to(Unit.bits).should.equal(unit.bits);
-    unit.to(Unit.satoshis).should.equal(unit.satoshis);
+    var unit = new Unit(1.3, 'FLO');
+    unit.to(Unit.FLO).should.equal(unit.FLO);
+    unit.to(Unit.mFLO).should.equal(unit.mFLO);
   });
 
   it('exposes shorthand conversion methods', function() {
-    var unit = new Unit(1.3, 'BTC');
-    unit.toBTC().should.equal(unit.BTC);
-    unit.toMilis().should.equal(unit.mBTC);
-    unit.toMillis().should.equal(unit.mBTC);
-    unit.toBits().should.equal(unit.bits);
-    unit.toSatoshis().should.equal(unit.satoshis);
+    var unit = new Unit(1.3, 'FLO');
+    unit.toFLO().should.equal(unit.FLO);
+    unit.toMilis().should.equal(unit.mFLO);
+    unit.toMillis().should.equal(unit.uFLO);
   });
 
   it('can convert to fiat', function() {
@@ -149,18 +104,18 @@ describe('Unit', function() {
     unit.atRate(350).should.equal(1.3);
     unit.to(350).should.equal(1.3);
 
-    unit = Unit.fromBTC(0.0123);
+    unit = Unit.fromFLO(0.0123);
     unit.atRate(10).should.equal(0.12);
   });
 
   it('toString works as expected', function() {
-    var unit = new Unit(1.3, 'BTC');
+    var unit = new Unit(1.3, 'FLO');
     should.exist(unit.toString);
     unit.toString().should.be.a('string');
   });
 
   it('can be imported and exported from/to JSON', function() {
-    var json = JSON.stringify({amount:1.3, code:'BTC'});
+    var json = JSON.stringify({amount:1.3, code:'FLO'});
     var unit = Unit.fromObject(JSON.parse(json));
     JSON.stringify(unit).should.deep.equal(json);
   });
@@ -171,17 +126,13 @@ describe('Unit', function() {
     }).to.throw();
   });
 
-  it('inspect method displays nicely', function() {
-    var unit = new Unit(1.3, 'BTC');
-    unit.inspect().should.equal('<Unit: 130000000 satoshis>');
-  });
 
   it('fails when the unit is not recognized', function() {
     expect(function() {
       return new Unit(100, 'USD');
     }).to.throw(errors.Unit.UnknownCode);
     expect(function() {
-      return new Unit(100, 'BTC').to('USD');
+      return new Unit(100, 'FLO').to('USD');
     }).to.throw(errors.Unit.UnknownCode);
   });
 
@@ -190,7 +141,7 @@ describe('Unit', function() {
       return new Unit(100, -123);
     }).to.throw(errors.Unit.InvalidRate);
     expect(function() {
-      return new Unit(100, 'BTC').atRate(-123);
+      return new Unit(100, 'FLO').atRate(-123);
     }).to.throw(errors.Unit.InvalidRate);
   });
 


### PR DESCRIPTION
Changed units from "BTC", "mBTC" and "uBTC" to "FLO", "mFLO" and "uFLO" respectively. In addition to that removed "bits" and "satoshis".